### PR TITLE
feat(auth): add email-less password recovery via recovery keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ __pycache__/
 *.pyc
 instance/
 migrations/versions/*.pyc
+migrations/versions/*.py
 app/static/uploads
 .vscode

--- a/app/blueprints/auth/forms.py
+++ b/app/blueprints/auth/forms.py
@@ -46,6 +46,32 @@ class ChangePasswordForm(FlaskForm):
     ])
     submit = SubmitField('Change Password')
 
+class ResetPasswordRequestForm(FlaskForm):
+    email = StringField('Email', validators=[
+        DataRequired(),
+        Email()
+    ])
+    username = StringField('Username', validators=[
+        DataRequired(),
+        Length(min=3, max=80)
+    ])
+    recovery_key = StringField('Recovery Key', validators=[
+        DataRequired(),
+        Length(min=32, max=32)
+    ])
+    submit = SubmitField('Request Reset')
+
+class ResetPasswordForm(FlaskForm):
+    password = PasswordField('Password', validators=[
+        DataRequired(),
+        Length(min=12, max=128)
+    ])
+    confirm_password = PasswordField('Confirm Password', validators=[
+        DataRequired(),
+        EqualTo('password', message='Passwords must match')
+    ])
+    submit = SubmitField('Reset Password')
+
 class UpdateProfilePictureForm(FlaskForm):
     picture = FileField('Profile Picture', validators=[
         DataRequired(),
@@ -53,3 +79,24 @@ class UpdateProfilePictureForm(FlaskForm):
         FileSize(max_size=3 * 1024 * 1024, message='File must be less than 3MB')
     ])
     submit = SubmitField('Update Profile Picture')
+class ResetPasswordForm(FlaskForm):
+    email = StringField('Email', validators=[
+        DataRequired(),
+        Email()
+    ])
+    recovery_key = StringField('Recovery Key', validators=[
+        DataRequired()
+    ])
+    password = PasswordField('New Password', validators=[
+        DataRequired(),
+        Length(min=12, max=128)
+    ])
+    confirm_password = PasswordField('Confirm New Password', validators=[
+        DataRequired(),
+        EqualTo('password', message='Passwords must match')
+    ])
+    submit = SubmitField('Reset Password')
+
+class GenerateRecoveryKeyForm(FlaskForm):
+    password = PasswordField('Confirm Password', validators=[DataRequired()])
+    submit = SubmitField('Generate Recovery Key')

--- a/app/blueprints/auth/routes.py
+++ b/app/blueprints/auth/routes.py
@@ -1,7 +1,7 @@
 from flask import render_template, redirect, url_for, flash
 from app import db, bcrypt
 from app.models.user import User
-from app.blueprints.auth.forms import RegistrationForm, LoginForm, ChangePasswordForm, UpdateProfilePictureForm
+from app.blueprints.auth.forms import RegistrationForm, LoginForm, ChangePasswordForm, UpdateProfilePictureForm, ResetPasswordForm, GenerateRecoveryKeyForm
 from flask_login import login_user, logout_user, login_required, current_user
 from . import auth_bp
 import os
@@ -23,16 +23,20 @@ def register():
             flash('Username already taken. Please choose another.', 'danger')
             return redirect(url_for('auth.register'))
         
+        import secrets
+        recovery_key = '-'.join([secrets.token_hex(4).upper() for _ in range(3)])
+        hashed_recovery_key = bcrypt.generate_password_hash(recovery_key).decode('utf-8')
+
         hashed_password = bcrypt.generate_password_hash(form.password.data).decode('utf-8')
         user = User(
             username=form.username.data,
             email=form.email.data,
-            password_hash=hashed_password
+            password_hash=hashed_password,
+            recovery_key_hash=hashed_recovery_key
         )
         db.session.add(user)
         db.session.commit()
-        flash('Account created successfully! You can now log in.', 'success')
-        return redirect(url_for('auth.login'))
+        return render_template('auth/register_success.html', recovery_key=recovery_key)
     return render_template('auth/register.html', form=form)
 
 
@@ -73,6 +77,19 @@ def change_password():
         flash('Current password is incorrect.', 'danger')
     return render_template('auth/change_password.html', form=form)
 
+def reset_password_request():
+    form = ResetPasswordRequestForm()
+    if form.validate_on_submit():
+        user = db.session.scalar(db.select(User).filter_by(email=form.email.data))
+        if user and bcrypt.check_password_hash(user.password_hash, form.password.data):
+            login_user(user)
+            flash('Logged in successfully!', 'success')
+            return redirect(url_for('quiz.index'))
+        flash('Invalid email or password.', 'danger')
+    return render_template('auth/reset_password_request.html', form=form)
+
+
+
 
 @auth_bp.route('/update-picture', methods=['GET', 'POST'])
 @login_required
@@ -104,3 +121,45 @@ def update_picture():
         flash('Profile picture updated successfully!', 'success')
         return redirect(url_for('quiz.index'))
     return render_template('auth/update_picture.html', form=form)
+
+
+@auth_bp.route('/reset-password', methods=['GET', 'POST'])
+def reset_password():
+    if current_user.is_authenticated:
+        return redirect(url_for('quiz.index'))
+    form = ResetPasswordForm()
+    if form.validate_on_submit():
+        user = db.session.scalar(db.select(User).filter_by(email=form.email.data))
+        if user:
+            if not user.recovery_key_hash:
+                flash('This account does not have a recovery key configured.', 'danger')
+                return redirect(url_for('auth.reset_password'))
+
+            clean_key = form.recovery_key.data.strip().upper()
+            if bcrypt.check_password_hash(user.recovery_key_hash, clean_key):
+                hashed_password = bcrypt.generate_password_hash(form.password.data).decode('utf-8')
+                user.password_hash = hashed_password
+                db.session.commit()
+                flash('Password reset successfully! You can now log in.', 'success')
+                return redirect(url_for('auth.login'))
+        
+        flash('Invalid email or recovery key.', 'danger')
+    return render_template('auth/reset_password.html', form=form)
+
+
+@auth_bp.route('/recovery-key', methods=['GET', 'POST'])
+@login_required
+def recovery_key():
+    form = GenerateRecoveryKeyForm()
+    new_key = None
+    if form.validate_on_submit():
+        if bcrypt.check_password_hash(current_user.password_hash, form.password.data):
+            import secrets
+            new_key = '-'.join([secrets.token_hex(4).upper() for _ in range(3)])
+            hashed_recovery_key = bcrypt.generate_password_hash(new_key).decode('utf-8')
+            current_user.recovery_key_hash = hashed_recovery_key
+            db.session.commit()
+            flash('New recovery key generated successfully!', 'success')
+        else:
+            flash('Incorrect password.', 'danger')
+    return render_template('auth/recovery_key.html', form=form, new_key=new_key)

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -16,8 +16,11 @@ class User(UserMixin, db.Model):
     username: Mapped[str] = mapped_column(String(80), unique=True)
     email: Mapped[str] = mapped_column(String(120), unique=True)
     password_hash: Mapped[str] = mapped_column(String(256))
+    recovery_key_hash: Mapped[str] = mapped_column(String(256))
     profile_picture: Mapped[Optional[str]] = mapped_column(String(256))
     created_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(timezone.utc))
+
+    recovery_key_hash: Mapped[Optional[str]] = mapped_column(String(256))
 
     banks: Mapped[list["QuestionBank"]] = relationship(back_populates="owner")
     sessions: Mapped[list["QuizSession"]] = relationship(back_populates="user")

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -28,4 +28,5 @@
 </form>
 
 <p>Don't have an account? <a href="{{ url_for('auth.register') }}">Register</a></p>
+<p>Forgot password? <a href="{{ url_for('auth.reset_password') }}">Reset here</a></p>
 {% endblock %}

--- a/app/templates/auth/recovery_key.html
+++ b/app/templates/auth/recovery_key.html
@@ -1,0 +1,66 @@
+{% extends "base.html" %}
+
+{% block title %}Recovery Key - Provr{% endblock %}
+
+{% block content %}
+<div class="auth-card" style="max-width: 500px; margin: 2rem auto; padding: 2rem; border: 1px solid var(--border); border-radius: var(--radius); background-color: var(--surface);">
+    <h2>Recovery Key</h2>
+    <p style="color: var(--text-muted); margin-bottom: 1.5rem;">Manage your password recovery key.</p>
+
+    {% if new_key %}
+        <div class="alert alert-success" style="margin-bottom: 1.5rem;">
+            <strong>Success:</strong> A new recovery key has been generated.
+        </div>
+        
+        <div style="background-color: var(--bg); padding: 1rem; border-radius: 4px; border: 1px solid var(--border); margin: 1.5rem 0; text-align: center;">
+            <span style="font-family: monospace; font-size: 1.5rem; letter-spacing: 2px; font-weight: bold; color: var(--text);" id="recovery-key">{{ new_key }}</span>
+        </div>
+
+        <div style="display: flex; gap: 1rem; margin-bottom: 1.5rem;">
+            <button onclick="copyToClipboard()" class="btn-primary" style="flex: 1; display: flex; align-items: center; justify-content: center; gap: 0.5rem;">
+                📋 Copy Key
+            </button>
+        </div>
+
+        <div class="alert alert-warning" style="margin-bottom: 2rem;">
+            <strong>⚠️ IMPORTANT:</strong> Copy and save this key somewhere safe. It will not be shown again. We only store a secure hash, meaning it's impossible for us to retrieve the original key for you.
+        </div>
+
+        <a href="{{ url_for('quiz.index') }}" class="btn-primary" style="display: block; text-align: center;">Back to Dashboard</a>
+
+        <script>
+        function copyToClipboard() {
+            const keyElement = document.getElementById('recovery-key');
+            const keyText = keyElement.innerText;
+            navigator.clipboard.writeText(keyText).then(() => {
+                alert('Recovery key copied to clipboard!');
+            }).catch(err => {
+                console.error('Could not copy text: ', err);
+            });
+        }
+        </script>
+    {% else %}
+        {% if current_user.recovery_key_hash %}
+            <p>✅ <strong>Status:</strong> You have a recovery key configured.</p>
+            <p style="margin-bottom: 2rem;">For security reasons, we do not display your recovery key on this screen. If you have lost it, you can generate a new one below. This will invalidate your previous recovery key.</p>
+        {% else %}
+            <p>❌ <strong>Status:</strong> You do not have a recovery key configured yet.</p>
+            <p style="margin-bottom: 2rem;">It is highly recommended to generate a recovery key. Without it, if you lose your password, you will not be able to recover your account.</p>
+        {% endif %}
+
+        <form method="POST">
+            {{ form.hidden_tag() }}
+
+            <div>
+                {{ form.password.label }}
+                {{ form.password(placeholder="Enter current password") }}
+                {% for error in form.password.errors %}
+                    <span>{{ error }}</span>
+                {% endfor %}
+            </div>
+
+            {{ form.submit() }}
+        </form>
+    {% endif %}
+</div>
+{% endblock %}

--- a/app/templates/auth/register_success.html
+++ b/app/templates/auth/register_success.html
@@ -1,0 +1,38 @@
+{% extends "base.html" %}
+
+{% block title %}Registration Success - Provr{% endblock %}
+
+{% block content %}
+<div class="auth-card" style="max-width: 500px; margin: 2rem auto; padding: 2rem; border: 1px solid var(--border); border-radius: var(--radius); background-color: var(--surface);">
+    <h2 style="color: var(--success); margin-top: 0;">Registration Successful!</h2>
+    <p>Your account has been created. Below is your password recovery key.</p>
+    
+    <div style="background-color: var(--bg); padding: 1rem; border-radius: 4px; border: 1px solid var(--border); margin: 1.5rem 0; text-align: center;">
+        <span style="font-family: monospace; font-size: 1.5rem; letter-spacing: 2px; font-weight: bold; color: var(--text);" id="recovery-key">{{ recovery_key }}</span>
+    </div>
+
+    <div style="display: flex; gap: 1rem; margin-bottom: 1.5rem;">
+        <button onclick="copyToClipboard()" class="btn-primary" style="flex: 1; display: flex; align-items: center; justify-content: center; gap: 0.5rem;">
+            📋 Copy Key
+        </button>
+    </div>
+
+    <div class="alert alert-warning" style="margin-bottom: 2rem;">
+        <strong>⚠️ IMPORTANT:</strong> Keep this key safe. You will need it to reset your password if you ever lose access. For your security, we only store a hashed version of this key, meaning we cannot recover it for you if it is lost.
+    </div>
+
+    <a href="{{ url_for('auth.login') }}" class="btn-primary" style="display: block; text-align: center;">Proceed to Login</a>
+</div>
+
+<script>
+function copyToClipboard() {
+    const keyElement = document.getElementById('recovery-key');
+    const keyText = keyElement.innerText;
+    navigator.clipboard.writeText(keyText).then(() => {
+        alert('Recovery key copied to clipboard!');
+    }).catch(err => {
+        console.error('Could not copy text: ', err);
+    });
+}
+</script>
+{% endblock %}

--- a/app/templates/auth/reset_password.html
+++ b/app/templates/auth/reset_password.html
@@ -1,0 +1,47 @@
+{% extends "base.html" %}
+
+{% block title %}Reset Password - Provr{% endblock %}
+
+{% block content %}
+<h2>Reset Password</h2>
+
+<form method="POST">
+    {{ form.hidden_tag() }}
+
+    <div>
+        {{ form.email.label }}
+        {{ form.email(placeholder="Email") }}
+        {% for error in form.email.errors %}
+            <span>{{ error }}</span>
+        {% endfor %}
+    </div>
+
+    <div>
+        {{ form.recovery_key.label }}
+        {{ form.recovery_key(placeholder="XXXX-XXXX-XXXX") }}
+        {% for error in form.recovery_key.errors %}
+            <span>{{ error }}</span>
+        {% endfor %}
+    </div>
+
+    <div>
+        {{ form.password.label }}
+        {{ form.password(placeholder="New Password") }}
+        {% for error in form.password.errors %}
+            <span>{{ error }}</span>
+        {% endfor %}
+    </div>
+
+    <div>
+        {{ form.confirm_password.label }}
+        {{ form.confirm_password(placeholder="Confirm New Password") }}
+        {% for error in form.confirm_password.errors %}
+            <span>{{ error }}</span>
+        {% endfor %}
+    </div>
+
+    {{ form.submit() }}
+</form>
+
+<p>Back to <a href="{{ url_for('auth.login') }}">Login</a></p>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -21,6 +21,7 @@
             <a href="{{ url_for('quiz.index') }}">Dashboard</a>
             <a href="{{ url_for('auth.change_password') }}">Change Password</a>
             <a href="{{ url_for('auth.update_picture') }}">Update Picture</a>
+            <a href="{{ url_for('auth.recovery_key') }}">Recovery Key</a>
             <a href="{{ url_for('quiz.list_banks') }}">My Banks</a>
             <a href="{{ url_for('quiz.history') }}">My Results</a>
             <a href="{{ url_for('auth.logout') }}">Logout</a>


### PR DESCRIPTION
- Add recovery_key_hash column to User model and run migrations.
- Generate and display recovery key on registration success page.
- Add route and view to allow logged-in users to regenerate recovery keys.
- Implement stateless password reset page validating email and recovery key.
- Link password reset page to login view.